### PR TITLE
(chore) O3-3968: Cache playwright browsers install step in E2E workflow 

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,17 +25,25 @@ jobs:
           node-version: 18
 
       - name: Cache dependencies
-        id: cache
+        id: cache-dependencies
         uses: actions/cache@v4
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.cache-dependencies.outputs.cache-hit != 'true'
         run: yarn install --immutable
 
+      - name: Cache Playwright browsers
+        id: cache-playwright
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+      
       - name: Install Playwright Browsers
+        if: steps.cache-playwright.outputs.cache-hit != 'true'
         run: npx playwright install chromium --with-deps
 
       - name: Build app


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
The current end-to-end test GitHub action takes a significant amount of time to install Playwright browsers during every run on the https://github.com/openmrs/openmrs-esm-cohortbuilder-app/  repo. To improve the efficiency of the CI pipeline, we should cache the Playwright browser installation to reduce the time spent installing browsers on every run.

## Screenshots


## Related Issue
Ticket: https://openmrs.atlassian.net/browse/O3-3968

## Other

