### PR TITLE
(chore) Bump Playwright

### DIFF
--- a/e2e/support/bamboo/playwright.Dockerfile
+++ b/e2e/support/bamboo/playwright.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.44.0-jammy
+FROM mcr.microsoft.com/playwright:v1.49.0-jammy
 
 ARG USER_ID
 ARG GROUP_ID


### PR DESCRIPTION
This PR upgrades playwright to the latest version 1.49.0. Release notes at https://playwright.dev/docs/release-notes