### PR TITLE
(chore) Update CI workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -10,8 +10,9 @@ on:
       - created
 
 env:
-  ESM_NAME: "@openmrs/esm-cohort-builder-app"
-  JS_NAME: "openmrs-esm-cohort-builder-app.js"
+  TURBO_API: 'http://127.0.0.1:9080'
+  TURBO_TOKEN: 'turbo-token'
+  TURBO_TEAM: ${{ github.repository_owner }}
 
 jobs:
   build:
@@ -19,83 +20,150 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js
+      - name: 🛠️ Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18.x"
-      - run: yarn install --immutable
-      - run: yarn verify
-      - run: yarn build
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+          node-version: "18"
+
+      - name: 💾 Cache dependencies
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+
+      - name: 📦 Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn install --immutable
+
+      - name: 🚀 Setup local cache server for Turborepo
+        uses: felixmosh/turborepo-gh-artifacts@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          server-token: ${{ env.TURBO_TOKEN }}
+
+      - name: 🧪 Run tests, lint and type checks
+        run: yarn verify
+
+      - name: 🏗️ Run build
+        run: yarn turbo run build
+
+      - name: 📤 Upload Artifacts
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: |
             dist
+          overwrite: true
 
   pre_release:
     runs-on: ubuntu-latest
-
     needs: build
-
     if: ${{ github.event_name == 'push' }}
 
     steps:
-      - run: echo "Uncomment the lines below and delete this one."
       - uses: actions/checkout@v4
-      - name: Download Artifacts
-        uses: actions/download-artifact@v4
-      - name: Use Node.js
+      - name: 🛠️ Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18.x"
-          registry-url: "https://registry.npmjs.org"
-      - run: yarn install --immutable
-      - run: yarn version "$(node -e "console.log(require('semver').inc(require('./package.json').version, 'patch'))")-pre.${{ github.run_number }}"
-      - run: yarn build
-      - run: git config user.email "info@openmrs.org" && git config user.name "OpenMRS CI"
-      - run: git add . && git commit -m "Prerelease version" --no-verify
-      - run: yarn config set npmAuthToken "${NODE_AUTH_TOKEN}" && yarn npm publish --access public --tag next
+          node-version: "18"
+
+      - name: 💾 Cache dependencies
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+
+      - name: 📦 Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn install --immutable
+
+      - name: 🚀 Setup local cache server for Turborepo
+        uses: felixmosh/turborepo-gh-artifacts@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          server-token: ${{ env.TURBO_TOKEN }}
+
+      - name: 🏷️ Version
+        run: yarn version "$(node -e "console.log(require('semver').inc(require('./package.json').version, 'patch'))")-pre.${{ github.run_number }}"
+
+      - name: 🏗️ Build
+        run: yarn turbo run build
+
+      - name: 🔧 Configure Git
+        run: git config user.email "info@openmrs.org" && git config user.name "OpenMRS CI"
+      - name: 💾 Commit changes
+        run: git add . && git commit -m "Prerelease version" --no-verify
+
+      - name: 🚀 Pre-release
+        run: yarn config set npmAuthToken "${NODE_AUTH_TOKEN}" && yarn npm publish --access public --tag next
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+      - name: 📤 Upload Artifacts
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: |
             dist
+          overwrite: true
 
   release:
     runs-on: ubuntu-latest
-
     needs: build
-
     if: ${{ github.event_name == 'release' }}
 
     steps:
       - uses: actions/checkout@v4
-      - name: Download Artifacts
+      - name: 📥 Download Artifacts
         uses: actions/download-artifact@v4
-      - name: Use Node.js
+      - name: 🛠️ Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18.x"
+          node-version: "18"
           registry-url: 'https://registry.npmjs.org'
-      - run: yarn install --immutable
-      - run: yarn config set npmAuthToken "${NODE_AUTH_TOKEN}" && yarn npm publish --access public
+
+      - name: 💾 Cache dependencies
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+
+      - name: 📦 Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn install --immutable
+
+      - name: 🚀 Setup local cache server for Turborepo
+        uses: felixmosh/turborepo-gh-artifacts@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          server-token: ${{ env.TURBO_TOKEN }}
+
+      - name: 🏗️ Build
+        run: yarn turbo run build
+
+      - name: 🚀 Publish to NPM
+        run: yarn config set npmAuthToken "${NODE_AUTH_TOKEN}" && yarn npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 
+      - name: 📤 Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: |
+            dist
+          overwrite: true
+
   deploy:
     runs-on: ubuntu-latest
-
     needs: pre_release
-
     if: ${{ github.event_name == 'push' }}
 
     steps:
-      - name: Trigger RefApp Build
-        uses: fjogeleit/http-request-action@master
+      - name: 🚀 Trigger RefApp Build
+        uses: fjogeleit/http-request-action@v1
         with:
           url: https://ci.openmrs.org/rest/api/latest/queue/O3-BF
           method: "POST"


### PR DESCRIPTION
This PR updates the main CI workflow for this repo to use Turborepo and cache dependencies. Importantly, it also ensures that the release job includes a build step to ensure that artifacts are built before being uploaded to NPM.