### PR TITLE
(chore) Migrate CI to shared openmrs-contrib-gha-workflows

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,6 +1,7 @@
 name: OpenMRS CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:
@@ -9,165 +10,18 @@ on:
     types:
       - created
 
-env:
-  TURBO_API: 'http://127.0.0.1:9080'
-  TURBO_TOKEN: 'turbo-token'
-  TURBO_TEAM: ${{ github.repository_owner }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: 📥 Checkout repo
-        uses: actions/checkout@v6
-      - name: 🛠️ Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 20
-
-      - name: 💾 Cache dependencies
-        id: cache
-        uses: actions/cache@v4
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-
-      - name: 📦 Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: yarn install --immutable
-
-      - name: 🚀 Setup local cache server for Turborepo
-        uses: felixmosh/turborepo-gh-artifacts@v4
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          server-token: ${{ env.TURBO_TOKEN }}
-
-      - name: 🧪 Run tests, lint and type checks
-        run: yarn verify
-
-      - name: 🏗️ Run build
-        run: yarn turbo run build
-
-      - name: 📤 Upload Artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: dist
-          path: |
-            dist
-          overwrite: true
-
-  pre_release:
-    runs-on: ubuntu-latest
-    needs: build
-    if: ${{ github.event_name == 'push' }}
-
-    steps:
-      - name: 📥 Checkout repo
-        uses: actions/checkout@v6
-      - name: 🛠️ Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 20
-
-      - name: 💾 Cache dependencies
-        id: cache
-        uses: actions/cache@v4
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-
-      - name: 📦 Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: yarn install --immutable
-
-      - name: 🚀 Setup local cache server for Turborepo
-        uses: felixmosh/turborepo-gh-artifacts@v4
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          server-token: ${{ env.TURBO_TOKEN }}
-
-      - name: 🏷️ Version
-        run: yarn version "$(node -e "console.log(require('semver').inc(require('./package.json').version, 'patch'))")-pre.${{ github.run_number }}"
-
-      - name: 🏗️ Build
-        run: yarn turbo run build
-
-      - name: 🔧 Configure Git
-        run: git config user.email "info@openmrs.org" && git config user.name "OpenMRS CI"
-      - name: 💾 Commit changes
-        run: git add . && git commit -m "Prerelease version" --no-verify
-
-      - name: 🚀 Pre-release
-        run: yarn config set npmAuthToken "${NODE_AUTH_TOKEN}" && yarn npm publish --access public --tag next
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-      - name: 📤 Upload Artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: dist
-          path: |
-            dist
-          overwrite: true
+    uses: openmrs/openmrs-contrib-gha-workflows/.github/workflows/build-frontend-module.yml@main
 
   release:
-    runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_dispatch'
     needs: build
-    if: ${{ github.event_name == 'release' }}
-
-    steps:
-      - name: 📥 Checkout repo
-        uses: actions/checkout@v6
-      - name: 📥 Download Artifacts
-        uses: actions/download-artifact@v4
-      - name: 🛠️ Use Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 20
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: 💾 Cache dependencies
-        id: cache
-        uses: actions/cache@v4
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-
-      - name: 📦 Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: yarn install --immutable
-
-      - name: 🚀 Setup local cache server for Turborepo
-        uses: felixmosh/turborepo-gh-artifacts@v4
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          server-token: ${{ env.TURBO_TOKEN }}
-
-      - name: 🏗️ Build
-        run: yarn turbo run build
-
-      - name: 🚀 Publish to NPM
-        run: yarn config set npmAuthToken "${NODE_AUTH_TOKEN}" && yarn npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-
-      - name: 📤 Upload Artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: dist
-          path: |
-            dist
-          overwrite: true
-
-  deploy:
-    runs-on: ubuntu-latest
-    needs: pre_release
-    if: ${{ github.event_name == 'push' }}
-
-    steps:
-      - name: 🚀 Trigger RefApp Build
-        uses: fjogeleit/http-request-action@v1
-        with:
-          url: https://ci.openmrs.org/rest/api/latest/queue/O3-BF
-          method: "POST"
-          customHeaders: '{ "Authorization": "Bearer ${{ secrets.BAMBOO_TOKEN }}" }'
+    uses: openmrs/openmrs-contrib-gha-workflows/.github/workflows/release-frontend-module.yml@main
+    secrets:
+      NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+      BOT_PAT: ${{ secrets.OMRS_BOT_GH_TOKEN }}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Migrates the CI workflow from a custom inline setup to the shared [openmrs-contrib-gha-workflows](https://github.com/openmrs/openmrs-contrib-gha-workflows) reusable workflows. This removes ~150 lines of duplicated CI configuration and replaces it with calls to build-frontend-module.yml and release-frontend-module.yml.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
